### PR TITLE
Make it work on macOS

### DIFF
--- a/JSONPath.sh
+++ b/JSONPath.sh
@@ -659,7 +659,7 @@ json() {
               arrays[j]=
               [[ -n ${closers[j]} ]] && {
                 let indent=j*4
-                printf "\n%0${indent}s${closers[j]}" ""
+                printf "\n%${indent}s${closers[j]}" ""
                 unset closers[j]
                 comma[j]=
               }
@@ -673,7 +673,7 @@ json() {
             arrays[j]=
             [[ -n ${closers[j]} ]] && {
               let indent=j*4
-              printf "\n%0${indent}s${closers[j]}" ""
+              printf "\n%${indent}s${closers[j]}" ""
               unset closers[j]
               comma[j]=
             }
@@ -695,7 +695,7 @@ json() {
           arrays[i]=
           [[ -n ${closers[i]} ]] && {
             let indent=i*4
-            printf "\n%0${indent}s${closers[i]}" ""
+            printf "\n%${indent}s${closers[i]}" ""
             unset closers[i]
             comma[i]=
           }
@@ -721,25 +721,25 @@ json() {
           # Object
           [[ $i -ge $broken ]] && {
             let indent=i*4
-            printf "${comma[i]}%0${indent}s{\n" ""
+            printf "${comma[i]}%${indent}s{\n" ""
             closers[i]='}'
             comma[i]=
           }
           let indent=(i+1)*4
-          printf "${comma[i]}%0${indent}s${path[i]}:\n" ""
+          printf "${comma[i]}%${indent}s${path[i]}:\n" ""
           comma[i]=",\n"
         else
           # Array
           if [[ ${arrays[i]} != 1 ]]; then
             let indent=i*4
-            printf "%0${indent}s" ""
+            printf "%${indent}s" ""
             echo "["
             closers[i]=']'
             arrays[i]=1
             comma[i]=
           else
             let indent=(i+1)*4
-            printf "\n%0${indent}s${closers[i-1]}" ""
+            printf "\n%${indent}s${closers[i-1]}" ""
             direction=$DOWN
             comma[i+1]=",\n"
           fi
@@ -752,25 +752,25 @@ json() {
         # Object
         [[ $direction -eq $DOWN ]] && {
           let indent=pathlen*4
-          printf "${comma[pathlen]}%0${indent}s{\n" ""
+          printf "${comma[pathlen]}%${indent}s{\n" ""
           closers[pathlen]='}'
           comma[pathlen]=
         }
         let indent=(pathlen+1)*4
-        printf "${comma[pathlen]}%0${indent}s" ""
+        printf "${comma[pathlen]}%${indent}s" ""
         echo -n "${path[-1]}:$value"
         comma[pathlen]=",\n"
       else
         # Array
         [[ ${arrays[i]} != 1 ]] && {
           let indent=(pathlen-0)*4
-          printf "%0${indent}s[\n" ""
+          printf "%${indent}s[\n" ""
           closers[pathlen]=']'
           comma[pathlen]=
           arrays[i]=1
         }
         let indent=(pathlen+1)*4
-        printf "${comma[pathlen]}%0${indent}s" ""
+        printf "${comma[pathlen]}%${indent}s" ""
         echo -n "$value"
         comma[pathlen]=",\n"
       fi
@@ -784,7 +784,7 @@ json() {
     for i in `seq $((pathlen)) -1 0`
     do
       let indent=i*4
-      printf "\n%0${indent}s${closers[i]}" ""
+      printf "\n%${indent}s${closers[i]}" ""
     done
     echo
   fi

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ yo, so it's a JSONPath implementation written in Bash - and it probably only wor
 
 [![travis](https://secure.travis-ci.org/mclarkson/JSONPath.sh.png?branch=master)](https://travis-ci.org/mclarkson/JSONPath.sh)
 
+Currently we rely on GNU implementations of the underlying tools. On OSX you can
+try wrapping the command like `./ensure_deps.sh ./JSONPath.sh`.
+
 ## Invocation
 
     JSONPath.sh [-b] [-i] [-j] [-h] [-p] [-u] [-f FILE] [pattern]
@@ -67,7 +70,7 @@ $ ./JSONPath.sh < package.json
 ["repository","url"]    "https://github.com/mclarkson/JSONPath.sh.git"
 ["bin","JSONPath.sh"]   "./JSONPath.sh"
 ["author"]      "Mark Clarkson <mark.clarkson@smorg.co.uk>"
-["scripts","test"]      "./all-tests.sh"
+["scripts","test"]      "./ensure_deps.sh ./all-tests.sh"
 ```
 
 more complex examples:

--- a/ensure_deps.sh
+++ b/ensure_deps.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+is_osx() {
+    test "$(uname -s)" == "Darwin"
+}
+
+test_gnu_compat() {
+    local error=0
+    if ! seq 0 -1 1 &> /dev/null; then
+        error=1
+        >&2 echo "Make sure you have GNU coreutils installed"
+    fi
+
+    if grep --version | grep 'BSD' &> /dev/null; then
+        error=1
+        >&2 echo "Make sure you have GNU grep or compatible installed"
+    fi
+
+    if ! sed --version &> /dev/null; then
+        error=1
+        >&2 echo "Make sure you have GNU sed or compatible installed"
+    fi
+
+    if [[ $error -gt 0 && is_osx ]]; then
+        >&2 echo "With homebrew you may install necessary deps via \`brew install grep gnu-sed coreutils\`"
+    fi
+
+    return $error
+}
+
+main() {
+    if is_osx; then
+        export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+        export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"
+        export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+    fi
+
+    test_gnu_compat
+
+    "$@"
+}
+
+main "$@"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {},
   "author": "Mark Clarkson <mark.clarkson@smorg.co.uk>",
   "scripts": {
-    "test": "./all-tests.sh"
+    "test": "./ensure_deps.sh ./all-tests.sh"
   }
 }


### PR DESCRIPTION
This solves two issues under macOS and should fix #6 :
- Dependency on GNU implementation specifics,
- Difference in `printf` across Linux and BSD (see respective commit).

I haven't investigated the dependency on GNU specifics further, but have resolved this for now by being upfront about the required dependencies for the README and when running tests.

The difference in printf I hope to avoid by simplifying the format somewhat. I've tested the change on OSX, Alpine and Ubuntu successfully.